### PR TITLE
working version shm-sync

### DIFF
--- a/source/shm-sync/server.c
+++ b/source/shm-sync/server.c
@@ -6,87 +6,57 @@
 #include "common/common.h"
 #include "shm-sync-common.h"
 
-void cleanup(int segment_id, void* shared_memory, struct Sync* sync) {
-	// Detach the shared memory from this process' address space.
-	// If this is the last process using this shared memory, it is removed.
-	shmdt(shared_memory);
+void communicate(struct Sync* sync,
+                 struct Arguments* args
+                 ) {
+    struct Benchmarks bench;
+    int message;
+    void* buffer = malloc(args->size);
 
-	/*
-		Deallocate manually for security. We pass:
-			1. The shared memory ID returned by shmget.
-			2. The IPC_RMID flag to schedule removal/deallocation
-				 of the shared memory.
-			3. NULL to the last struct parameter, as it is not relevant
-				 for deletion (it is populated with certain fields for other
-				 calls, notably IPC_STAT, where you would pass a struct shmid_ds*).
-	*/
-	shmctl(segment_id, IPC_RMID, NULL);
+    // Wait for signal from client
+    sync_wait(sync->mutex);
+    setup_benchmarks(&bench);
 
-	destroy_sync(sync);
-}
+    for (message = 0; message < args->count; ++message) {
+        bench.single_start = now();
 
+        //printf("1\n");
 
-void communicate(void* shared_memory,
-								 struct Arguments* args,
-								 struct Sync* sync) {
-	struct Benchmarks bench;
-	int message;
-	void* buffer = malloc(args->size);
+        // Write into the memory
+        memset(sync->shared_memory, '1', args->size);
 
-	// Wait for signal from client
-	sync_wait(sync);
-	setup_benchmarks(&bench);
+        sync_notify(sync->mutex);
+        sync_wait(sync->mutex);
 
-	for (message = 0; message < args->count; ++message) {
-		bench.single_start = now();
+        //printf("2\n");
 
-		printf("1\n");
+        // Read
+        memcpy(buffer, sync->shared_memory, args->size);
 
-		// Write into the memory
-		memset(shared_memory, '1', args->size);
+        sync_notify(sync->mutex);
 
-		sync_notify(sync);
-		sync_wait(sync);
+        //printf("3\n");
 
-		printf("2\n");
+        benchmark(&bench);
+    }
 
-		// Read
-		memcpy(buffer, shared_memory, args->size);
-
-		sync_notify(sync);
-
-		printf("3\n");
-
-		benchmark(&bench);
-	}
-
-	evaluate(&bench, args);
-	free(buffer);
+    evaluate(&bench, args);
+    free(buffer);
 }
 
 int main(int argc, char* argv[]) {
-	// The identifier for the shared memory segment
-	int segment_id;
+    // The synchronization object
+    struct Sync sync;
 
-	// The *actual* shared memory, that this and other
-	// processes can read and write to as if it were
-	// any other plain old memory
-	void* shared_memory;
+    // Fetch command-line arguments
+    struct Arguments args;
+    parse_arguments(&args, argc, argv);
 
-	// The synchronization object
-	struct Sync* sync;
+    create_sync(&sync, &args);
 
-	// Fetch command-line arguments
-	struct Arguments args;
-	parse_arguments(&args, argc, argv);
+    communicate(&sync, &args);
 
-	segment_id = create_segment(&args);
-	shared_memory = attach_segment(segment_id, &args);
-	sync = create_sync(shared_memory, &args);
+    cleanup(&sync);
 
-	communicate(shared_memory, &args, sync);
-
-	cleanup(segment_id, shared_memory, sync);
-
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/source/shm-sync/shm-sync-common.c
+++ b/source/shm-sync/shm-sync-common.c
@@ -4,173 +4,216 @@
 #include "common/utility.h"
 #include "shm-sync-common.h"
 
+void cleanup(struct Sync* sync) {
+    // Detach the shared memory from this process' address space.
+    // If this is the last process using this shared memory, it is removed.
+    shmdt(sync->shared_memory);
+
+    /*
+        Deallocate manually for security. We pass:
+            1. The shared memory ID returned by shmget.
+            2. The IPC_RMID flag to schedule removal/deallocation
+                 of the shared memory.
+            3. NULL to the last struct parameter, as it is not relevant
+                 for deletion (it is populated with certain fields for other
+                 calls, notably IPC_STAT, where you would pass a struct shmid_ds*).
+    */
+    shmctl(sync->segment_id, IPC_RMID, NULL);
+    if (sync->mutex_created) {
+        destroy_sync(sync);
+    }
+}
+
 
 void init_sync(struct Sync* sync) {
-	// These structures are used to initialize mutexes
-	// and condition variables. We will use them to set
-	// the PTHREAD_PROCESS_SHARED attribute, which enables
-	// more than one process (and any thread in any of those
-	// processes) to access the mutex and condition variable.
-	pthread_mutexattr_t mutex_attributes;
-	pthread_condattr_t condition_attributes;
+    // These structures are used to initialize mutexes
+    // and condition variables. We will use them to set
+    // the PTHREAD_PROCESS_SHARED attribute, which enables
+    // more than one process (and any thread in any of those
+    // processes) to access the mutex and condition variable.
+    pthread_mutexattr_t mutex_attributes;
+    pthread_condattr_t condition_attributes;
 
-	// These methods initialize the attribute structures
-	// with default values so that we must only change
-	// the one we are interested in.
-	if (pthread_mutexattr_init(&mutex_attributes) != 0) {
-		throw("Error initializing mutex attributes");
-	}
-	if (pthread_condattr_init(&condition_attributes) != 0) {
-		throw("Error initializing condition variable attributes");
-	}
+    // These methods initialize the attribute structures
+    // with default values so that we must only change
+    // the one we are interested in.
+    if (pthread_mutexattr_init(&mutex_attributes) != 0) {
+        throw("Error initializing mutex attributes");
+    }
+    if (pthread_condattr_init(&condition_attributes) != 0) {
+        throw("Error initializing condition variable attributes");
+    }
 
-	// Here we set the "process-shared"-attribute of the mutex
-	// and condition variable to PTHREAD_PROCESS_SHARED. This
-	// means multiple processes may access these objects. If
-	// we wouldn't do this, the attribute would be PTHREAD_PROCESS
-	// _PRIVATE, where only threads created by the process who
-	// initialized the objects would be allowed to access them.
-	// By passing PTHREAD_PROCESS_SHARED the objects may also live
-	// longer than the process creating them.
-	// clang-format off
-	if (pthread_mutexattr_setpshared(
-				&mutex_attributes, PTHREAD_PROCESS_SHARED) != 0) {
-		throw("Error setting process-shared attribute for mutex");
-	}
+    // Here we set the "process-shared"-attribute of the mutex
+    // and condition variable to PTHREAD_PROCESS_SHARED. This
+    // means multiple processes may access these objects. If
+    // we wouldn't do this, the attribute would be PTHREAD_PROCESS
+    // _PRIVATE, where only threads created by the process who
+    // initialized the objects would be allowed to access them.
+    // By passing PTHREAD_PROCESS_SHARED the objects may also live
+    // longer than the process creating them.
+    // clang-format off
+    if (pthread_mutexattr_setpshared(
+                &mutex_attributes, PTHREAD_PROCESS_SHARED) != 0) {
+        throw("Error setting process-shared attribute for mutex");
+    }
 
-	if (pthread_condattr_setpshared(
-				&condition_attributes, PTHREAD_PROCESS_SHARED) != 0) {
-		throw("Error setting process-shared attribute for condition variable");
-	}
-	// clang-format on
+    if (pthread_condattr_setpshared(
+                &condition_attributes, PTHREAD_PROCESS_SHARED) != 0) {
+        throw("Error setting process-shared attribute for condition variable");
+    }
+    // clang-format on
 
-	// Initialize the mutex and condition variable and pass the attributes
-	if (pthread_mutex_init(&sync->mutex, &mutex_attributes) != 0) {
-		throw("Error initializing mutex");
-	}
-	if (pthread_cond_init(&sync->condition, &condition_attributes) != 0) {
-		throw("Error initializing condition variable");
-	}
+    // Initialize the mutex and condition variable and pass the attributes
+    if (pthread_mutex_init(&sync->mutex->mutex, &mutex_attributes) != 0) {
+        throw("Error initializing mutex");
+    }
+    if (pthread_cond_init(&sync->mutex->condition, &condition_attributes) != 0) {
+        throw("Error initializing condition variable");
+    }
 
-	// Destroy the attribute objects
-	if (pthread_mutexattr_destroy(&mutex_attributes)) {
-		throw("Error destroying mutex attributes");
-	}
-	if (pthread_condattr_destroy(&condition_attributes)) {
-		throw("Error destroying condition variable attributes");
-	}
+    // Destroy the attribute objects
+    if (pthread_mutexattr_destroy(&mutex_attributes)) {
+        throw("Error destroying mutex attributes");
+    }
+    if (pthread_condattr_destroy(&condition_attributes)) {
+        throw("Error destroying condition variable attributes");
+    }
+
+    sync->mutex->count = 0;
 }
 
 void destroy_sync(struct Sync* sync) {
-	if (pthread_mutex_destroy(&sync->mutex)) {
-		throw("Error destroying mutex");
-	}
-	if (pthread_cond_destroy(&sync->condition)) {
-		throw("Error destroying condition variable");
-	}
+    if (pthread_mutex_destroy(&sync->mutex->mutex)) {
+        throw("Error destroying mutex");
+    }
+    if (pthread_cond_destroy(&sync->mutex->condition)) {
+        throw("Error destroying condition variable");
+    }
 }
 
-void sync_wait(struct Sync* sync) {
-	// Lock the mutex
-	if (pthread_mutex_lock(&sync->mutex) != 0) {
-		throw("Error locking mutex");
-	}
+void sync_wait(struct Mutex *sync) {
+    // Lock the mutex
+    if (pthread_mutex_lock(&sync->mutex) != 0) {
+        throw("Error locking mutex");
+    }
 
-	// Move into waiting for the condition variable to be signalled.
-	// For this, it is essential that the mutex first be locked (above)
-	// to avoid data races on the condition variable (e.g. the signal
-	// being sent before the waiting process has begun). In fact, behaviour
-	// is undefined otherwise. Once the mutex has begun waiting, the mutex
-	// is unlocked so that other threads may do something and eventually
-	// signal the condition variable. At that point, this thread wakes up
-	// and *re-acquires* the lock immediately. As such, when this method
-	// returns the lock will be owned by the calling thread.
-	if (pthread_cond_wait(&sync->condition, &sync->mutex) != 0) {
-		throw("Error waiting for condition variable");
-	}
+    // Move into waiting for the condition variable to be signalled.
+    // For this, it is essential that the mutex first be locked (above)
+    // to avoid data races on the condition variable (e.g. the signal
+    // being sent before the waiting process has begun). In fact, behaviour
+    // is undefined otherwise. Once the mutex has begun waiting, the mutex
+    // is unlocked so that other threads may do something and eventually
+    // signal the condition variable. At that point, this thread wakes up
+    // and *re-acquires* the lock immediately. As such, when this method
+    // returns the lock will be owned by the calling thread.
+    while (sync->count == 0) {
+        if (pthread_cond_wait(&sync->condition, &sync->mutex) != 0) {
+            throw("Error waiting for condition variable");
+        }
+    }
+    sync->count --;
+    if (pthread_mutex_unlock(&sync->mutex) != 0) {
+        throw("Error unlocking mutex");
+    }
+
 }
 
-void sync_notify(struct Sync* sync) {
-	// Signals to a single thread waiting on the condition variable
-	// to wake up, if any such thread exists. An alternative would be
-	// to call pthread_cond_broadcast, in which case *all* waiting
-	// threads would be woken up.
-	if (pthread_cond_signal(&sync->condition) != 0) {
-		throw("Error signalling condition variable");
-	}
+void sync_notify(struct Mutex* sync) {
+    if (pthread_mutex_lock(&sync->mutex) != 0) {
+        throw("Error locking mutex");
+    }
+    // Signals to a single thread waiting on the condition variable
+    // to wake up, if any such thread exists. An alternative would be
+    // to call pthread_cond_broadcast, in which case *all* waiting
+    // threads would be woken up.
+    if (sync->count == 0) {
+        if (pthread_cond_signal(&sync->condition) != 0) {
+            throw("Error signalling condition variable");
+        }
+    }
+    sync->count++;
+    if (pthread_mutex_unlock(&sync->mutex) != 0) {
+        throw("Error unlocking mutex");
+    }
 }
 
 #include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
 
-int create_segment(struct Arguments* args) {
-	// The identifier for the shared memory segment
-	int segment_id;
+void create_sync(struct Sync *sync, struct Arguments* args) {
 
-	// Key for the memory segment
-	key_t segment_key = generate_key("shm");
+    memset(sync, 0, sizeof(struct Sync));
 
-	// The size for the segment
-	int size = args->size + sizeof(*(struct Sync*)0);
+    // The identifier for the shared memory segment
 
-	/*
-		The call that actually allocates the shared memory segment.
-		Arguments:
-			1. The shared memory key. This must be unique across the OS.
-			2. The number of bytes to allocate. This will be rounded up to the OS'
-				 pages size for alignment purposes.
-			3. The creation flags and permission bits, where:
-				 - IPC_CREAT means that a new segment is to be created
-				 - IPC_EXCL means that the call will fail if
-					 the segment-key is already taken (removed)
-				 - 0666 means read + write permission for user, group and world.
-		When the shared memory key already exists, this call will fail. To see
-		which keys are currently in use, and to remove a certain segment, you
-		can use the following shell commands:
-			- Use `ipcs -m` to show shared memory segments and their IDs
-			- Use `ipcrm -m <segment_id>` to remove/deallocate a shared memory segment
-	*/
-	segment_id = shmget(segment_key, size, IPC_CREAT | 0666);
+    // Key for the memory segment
+    key_t segment_key = generate_key("shm");
 
-	if (segment_id < 0) {
-		throw("Error allocating segment");
-	}
+    // The size for the segment
+    int size = args->size + sizeof(*(struct Sync*)0);
 
-	return segment_id;
-}
+    /*
+        The call that actually allocates the shared memory segment.
+        Arguments:
+            1. The shared memory key. This must be unique across the OS.
+            2. The number of bytes to allocate. This will be rounded up to the OS'
+                 pages size for alignment purposes.
+            3. The creation flags and permission bits, where:
+                 - IPC_CREAT means that a new segment is to be created
+                 - IPC_EXCL means that the call will fail if
+                     the segment-key is already taken (removed)
+                 - 0666 means read + write permission for user, group and world.
+        When the shared memory key already exists, this call will fail. To see
+        which keys are currently in use, and to remove a certain segment, you
+        can use the following shell commands:
+            - Use `ipcs -m` to show shared memory segments and their IDs
+            - Use `ipcrm -m <segment_id>` to remove/deallocate a shared memory segment
+    */
+    sync->segment_id = shmget(segment_key, size, IPC_CREAT | IPC_EXCL | 0666);
+    sync->mutex_created  = 1;
+    if (EEXIST == errno) {
+        printf("[%d] shm exists\n", getpid());
+        sync->segment_id = shmget(segment_key, size, 0666);
+        sync->mutex_created = 0;
+    }
+    else {
+        printf("[%d] create shm\n", getpid());
+    }
 
-void* attach_segment(int segment_id, struct Arguments* args) {
-	void* shared_memory;
-	/*
+    if (sync->segment_id < 0) {
+        throw("Error allocating segment");
+    }
+
+        /*
 Once the shared memory segment has been created, it must be
 attached to the address space of each process that wishes to
 use it. For this, we pass:
-	1. The segment ID returned by shmget
-	2. A pointer at which to attach the shared memory segment. This
-		 address must be page-aligned. If you simply pass NULL, the OS
-		 will find a suitable region to attach the segment.
-	3. Flags, such as:
-		 - SHM_RND: round the second argument (the address at which to
-			 attach) down to a multiple of the page size. If you don't
-			 pass this flag but specify a non-null address as second argument
-			 you must ensure page-alignment yourself.
-		 - SHM_RDONLY: attach for reading only (independent of access bits)
+    1. The segment ID returned by shmget
+    2. A pointer at which to attach the shared memory segment. This
+         address must be page-aligned. If you simply pass NULL, the OS
+         will find a suitable region to attach the segment.
+    3. Flags, such as:
+         - SHM_RND: round the second argument (the address at which to
+             attach) down to a multiple of the page size. If you don't
+             pass this flag but specify a non-null address as second argument
+             you must ensure page-alignment yourself.
+         - SHM_RDONLY: attach for reading only (independent of access bits)
 shmat will return a pointer to the address space at which it attached the
 shared memory. Children processes created with fork() inherit this segment.
 */
-	shared_memory = shmat(segment_id, NULL, 0);
+    sync->shared_memory = shmat(sync->segment_id, NULL, 0);
 
-	if (shared_memory < 0) {
-		throw("Could not attach segment");
-	}
+    if (sync->shared_memory < 0) {
+        throw("Could not attach segment");
+    }
 
-	memset(shared_memory, 0, args->size);
+    memset(sync->shared_memory, 0, args->size);
 
-	return shared_memory;
-}
+    sync->mutex = (struct Mutex *)(sync->shared_memory + args->size);
+    if (sync->mutex_created) {
+        init_sync(sync);
+    }
 
-struct Sync* create_sync(void* shared_memory, struct Arguments* args) {
-	struct Sync* sync = (struct Sync*)shared_memory + args->size;
-	init_sync(sync);
-
-	return sync;
 }

--- a/source/shm-sync/shm-sync-common.h
+++ b/source/shm-sync/shm-sync-common.h
@@ -2,28 +2,34 @@
 #define SHM_SYNC_COMMON_H
 
 #include <pthread.h>
+#include <sys/ipc.h>
 #include <sys/shm.h>
 
 struct Arguments;
 
-struct Sync {
-	pthread_mutex_t mutex;
-	pthread_cond_t condition;
+struct Mutex {
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    int count;
 };
+
+struct Sync {
+    int segment_id;
+    void *shared_memory;
+    struct Mutex *mutex;
+    int mutex_created;
+};
+
+void cleanup(struct Sync* sync);
 
 void init_sync(struct Sync* sync);
 
 void destroy_sync(struct Sync* sync);
 
-void sync_wait(struct Sync* sync);
+void sync_wait(struct Mutex* sync);
 
-void sync_notify(struct Sync* sync);
+void sync_notify(struct Mutex* sync);
 
-
-int create_segment(struct Arguments* args);
-
-void* attach_segment(int segment_id, struct Arguments* args);
-
-struct Sync* create_sync(void* shared_memory, struct Arguments* args);
+void create_sync(struct Sync* sync, struct Arguments* args);
 
 #endif /* SHM_SYNC_COMMON_H */


### PR DESCRIPTION
fix two troubles with using pthread process shared
1. need initialize mutex and condition variable only once at server process for example
2. fix signal and wait functions on shared mutex and condition according to example in man https://linux.die.net/man/3/pthread_mutexattr_init section 'Process Shared Memory and Synchronization'

this solution has issue: client must start with some delay before server process is initilized shared segment and mutex, I insert sleep for a second in code