### PR TITLE
Fix wrong memory allocation size

### DIFF
--- a/source/domain/server.c
+++ b/source/domain/server.c
@@ -23,7 +23,7 @@ void communicate(int connection, struct Arguments* args, int busy_waiting) {
 	int message;
 	void* buffer;
 
-	buffer = malloc(args->count);
+	buffer = malloc(args->size);
 	setup_benchmarks(&bench);
 
 	for (message = 0; message < args->count; ++message) {


### PR DESCRIPTION
I'm getting a crash in the domain benchmark. I think the size of the malloc is wrong. This is a simple one line fix.