### PR TITLE
zeromq timming fixed

### DIFF
--- a/source/zeromq/client.c
+++ b/source/zeromq/client.c
@@ -12,9 +12,15 @@
 #include "common/common.h"
 
 void communicate(void* socket, struct Arguments* args) {
+	struct Benchmarks bench;
+	int message;
+
+	setup_benchmarks(&bench);
 	void* buffer = malloc(args->size);
 
-	for (; args->count > 0; --args->count) {
+	for (message = 0; message < args->count; ++message) {
+		bench.single_start = now();
+
 		// Send data to the server (flags = 0)
 		if (zmq_send(socket, buffer, args->size, 0) < args->size) {
 			throw("Error sending on client-side");
@@ -24,8 +30,11 @@ void communicate(void* socket, struct Arguments* args) {
 		if (zmq_recv(socket, buffer, args->size, 0) < args->size) {
 			throw("Error receiving on client-side");
 		}
+
+		benchmark(&bench);
 	}
 
+	evaluate(&bench, args);
 	free(buffer);
 }
 

--- a/source/zeromq/server.c
+++ b/source/zeromq/server.c
@@ -7,15 +7,11 @@
 #include "common/common.h"
 
 void communicate(void* socket, struct Arguments* args) {
-	struct Benchmarks bench;
-	int message;
 	void* buffer;
 
 	buffer = malloc(args->size);
-	setup_benchmarks(&bench);
 
-	for (message = 0; message < args->count; ++message) {
-		bench.single_start = now();
+	for (; args->count > 0; --args->count) {
 
 		// Receive data from the client (flags = 0)
 		if (zmq_recv(socket, buffer, args->size, 0) < args->size) {
@@ -28,11 +24,7 @@ void communicate(void* socket, struct Arguments* args) {
 		if (zmq_send(socket, buffer, args->size, 0) < args->size) {
 			throw("Error sending on server-side");
 		}
-
-		benchmark(&bench);
 	}
-
-	evaluate(&bench, args);
 
 	free(buffer);
 }


### PR DESCRIPTION
- stopwatch should be started by the one who sends the first message
- the ZMQ_REQ context forced client to start communication, means client must start stopwatch