### PR TITLE
domain: ack messages with one byte to closer match fifo benchmark

### DIFF
--- a/source/domain/client.c
+++ b/source/domain/client.c
@@ -23,10 +23,7 @@ void communicate(int connection, struct Arguments* args, int busy_waiting) {
 			throw("Error receiving on client-side");
 		}
 
-		// Dummy operation
-		memset(buffer, '*', args->size);
-
-		if (send(connection, buffer, args->size, 0) == -1) {
+		if (send(connection, buffer, 1, 0) == -1) {
 			throw("Error sending on client-side");
 		}
 	}

--- a/source/domain/server.c
+++ b/source/domain/server.c
@@ -24,6 +24,8 @@ void communicate(int connection, struct Arguments* args, int busy_waiting) {
 	void* buffer;
 
 	buffer = malloc(args->size);
+	memset(buffer, '*', args->size);
+
 	setup_benchmarks(&bench);
 
 	for (message = 0; message < args->count; ++message) {
@@ -33,9 +35,7 @@ void communicate(int connection, struct Arguments* args, int busy_waiting) {
 			throw("Error sending on server-side");
 		}
 
-		memset(buffer, '*', args->size);
-
-		if (receive(connection, buffer, args->size, busy_waiting) == -1) {
+		if (receive(connection, buffer, 1, busy_waiting) == -1) {
 			throw("Error receiving on server-side");
 		}
 


### PR DESCRIPTION
pipe/fifo benchmark signals but domain replies with full payload, which
causes a significant performance difference.