### PR TITLE
Cleanup

### DIFF
--- a/source/mmap/client.c
+++ b/source/mmap/client.c
@@ -125,7 +125,6 @@ int main(int argc, char* argv[]) {
 	}
 
 	remove("/tmp/mmap");
-	close(file_descriptor);
 
 	return EXIT_SUCCESS;
 }

--- a/source/mmap/server.c
+++ b/source/mmap/server.c
@@ -141,7 +141,5 @@ int main(int argc, char *argv[]) {
 		throw("Error unmapping file!");
 	}
 
-	close(file_descriptor);
-
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR removes two apparently useless statements: the file descriptor was closed before and doesn't need to be closed again.